### PR TITLE
feat: embed JS from external files

### DIFF
--- a/faceloader.go
+++ b/faceloader.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -139,6 +140,9 @@ func maybeLogin(ctx context.Context, username string, password string) error {
 	return err
 }
 
+//go:embed more.js
+var more string
+
 // find links to Facebook events from a url, using Chrome so that we do it as a logged-in Facebook user
 func getFacebookEventLinks(ctx context.Context, pageUrl string) []string {
 	var links []string
@@ -151,11 +155,11 @@ func getFacebookEventLinks(ctx context.Context, pageUrl string) []string {
 		chromedp.Navigate(pageUrl),
 		chromedp.WaitReady(waitSelector),
 		// We can't use chromedp.Click() because the 'See more' link might not actually exist
-		chromedp.EvaluateAsDevTools("let more = document.querySelector('div[aria-label=\"See more\"]'); if (more){more.click()};''", &res),
+		chromedp.EvaluateAsDevTools(more, &res),
 		chromedp.Sleep(2 * time.Second),
-		chromedp.EvaluateAsDevTools("more = document.querySelector('div[aria-label=\"See more\"]'); if (more){more.click()};''", &res),
+		chromedp.EvaluateAsDevTools(more, &res),
 		chromedp.Sleep(2 * time.Second),
-		chromedp.EvaluateAsDevTools("more = document.querySelector('div[aria-label=\"See more\"]'); if (more){more.click()};''", &res),
+		chromedp.EvaluateAsDevTools(more, &res),
 		chromedp.Sleep(2 * time.Second),
 		chromedp.Nodes(linksSelector, &nodes),
 	})

--- a/more.js
+++ b/more.js
@@ -1,0 +1,5 @@
+more = document.querySelector('div[aria-label="See more"]');
+if (more) {
+	more.click();
+}
+("");


### PR DESCRIPTION
It looks like the event pages don't use JSON-LD which is why they aren't returning the info we need. If that's the case we'll probably need to do some messy DOM exploration and this will likely be the part that needs updating most frequently. It would be nice to write it in separate JS files and get help from the editor.

In the spirit conventional commits I've made the change as small as possible.

I've never used Go or JSON-LD so proceed with caution!